### PR TITLE
fix prettier config and add error, loading, permission handling for invite page

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "singleQuote": true,
   "printWidth": 70,
   "editor.formatOnSave": false,
-// Enable per-language
-"[javascript]": {
+  "[javascript]": {
     "editor.formatOnSave": true
+  }
 }

--- a/components/Invites.js
+++ b/components/Invites.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 /////////////////MUI
 //import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
-import { Grid, Paper, Typography} from '@material-ui/core';
+import { Grid, Paper, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 ///////////////////Utils & Context API
@@ -22,7 +22,6 @@ import { Button } from '@material-ui/core';
 import swal from 'sweetalert';
 import '../assets/sweetalert.min.js';
 
-
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
@@ -32,7 +31,7 @@ const useStyles = makeStyles(theme => ({
     margin: 'auto',
     maxWidth: '100%',
     margin: '10px',
-    borderRadius: '12px'
+    borderRadius: '12px',
   },
   title: {
     fontWeight: 'bold',
@@ -41,24 +40,40 @@ const useStyles = makeStyles(theme => ({
     textShadow: '1.5px #3f50b5',
     fontFamily: 'Roboto Condensed',
     marginTop: '5px',
-  }
+  },
 }));
 
 const Invites = () => {
   const classes = useStyles();
   const ceoProps = useContext(CeoContext);
   const employeeProps = useContext(EmployeeContext);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  let props;
-  if (Object.keys(ceoProps).length > 0) {
-    props = ceoProps;
-    props.getAllInvitations();
-  }
-  if (Object.keys(employeeProps).length > 0) {
-    props = employeeProps;
-  }
+  useEffect(() => {
+    const init = async () => {
+      let props;
+      if (Object.keys(ceoProps).length > 0) {
+        props = ceoProps;
+        try {
+          await props.getAllInvitations();
+          setLoading(false);
+        } catch (e) {
+          setError(e.message);
+          setLoading(false);
+        }
+      }
+      if (Object.keys(employeeProps).length > 0) {
+        props = employeeProps;
+        setLoading(false);
+        setError("You don't have access to this data.");
+      }
+    };
 
-  const handleInvitation = (invitation) => {
+    init();
+  }, []);
+
+  const handleInvitation = invitation => {
     swal({
       title: 'Can you make the meeting?',
       text: 'Please either accept or decline.',
@@ -66,135 +81,207 @@ const Invites = () => {
         element: 'input',
         attributes: {
           placeholder: 'Send a note back.',
-        }
+        },
       },
       icon: 'warning',
       buttons: {
         confirm: {
           text: 'ACCEPT',
-          value: true
+          value: true,
         },
-        cancel: 'DECLINE'
-      }
+        cancel: 'DECLINE',
+      },
     }).then(value => {
       if (value) {
         swal({
           title: 'Lunch invitation accepted!',
           icon: 'success',
-          button: true
+          button: true,
         }).then(() => {
           const answer = {
             status: true,
-            reply: value
+            reply: value,
           };
           props.handleInvitation(invitation, answer);
         });
       } else {
         const answer = {
           status: false,
-          reply: swal.getState().actions.confirm.value
+          reply: swal.getState().actions.confirm.value,
         };
         props.handleInvitation(invitation, answer);
       }
     });
   };
 
+  if (loading) {
+    return (
+      <div>
+        <p className="title">Invites</p>
+        <div className="data-big">
+          <img src={Loader}></img>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div>
+        <p className="title">Invites</p>
+        <div className="data-big">{error}</div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <p className="title">Invites</p>
-      {
-        props.invitations ?
-          <div>
-            <div className={classes.root}>
-            </div>
-            {props.invitations.map((item) => { if (item.status == 'pending') {
+      {props.invitations ? (
+        <div>
+          <div className={classes.root}></div>
+          {props.invitations.map(item => {
+            if (item.status == 'pending') {
               return (
-                <Paper key={item.invitationId} className={classes.paper}>
+                <Paper
+                  key={item.invitationId}
+                  className={classes.paper}
+                >
                   <Grid container spacing={2}>
                     <Grid item xs={12} sm container>
-                      <Grid item xs container direction="column" spacing={2}>
+                      <Grid
+                        item
+                        xs
+                        container
+                        direction="column"
+                        spacing={2}
+                      >
                         <Grid item xs>
-                          <span className="date">{moment(item.invitationDate).format('MMMM Do YYYY').toUpperCase()} AT {item.invitationTime.toUpperCase()}</span>
+                          <span className="date">
+                            {moment(item.invitationDate)
+                              .format('MMMM Do YYYY')
+                              .toUpperCase()}{' '}
+                            AT {item.invitationTime.toUpperCase()}
+                          </span>
 
-                          <Typography className={classes.title} gutterBottom variant="subtitle1">
-                             Meeting with {item.employeeName ? item.employeeName : 'CEO'}
+                          <Typography
+                            className={classes.title}
+                            gutterBottom
+                            variant="subtitle1"
+                          >
+                            Meeting with{' '}
+                            {item.employeeName
+                              ? item.employeeName
+                              : 'CEO'}
                           </Typography>
-                          <p>
-                            {item.comments}
-                          </p>
+                          <p>{item.comments}</p>
                         </Grid>
                       </Grid>
                       <Grid item>
-                        {
-                          item.employeeName ? <p>{item.status === 'accepted' ? (
-                            <div className="status">
-                              <CheckCircleOutlineIcon style={{ color: 'green' }} />
-                              <div>accepted</div>
-                            </div>
-                          ) : (
-                            <div className="status">
-                              <HelpOutlineIcon style={{ color: 'purple' }} />
-                              <div>pending</div>
-                            </div>
-                          )}</p> : <p>
-                            { item.status === 'pending' ?
-                              <Button onClick={() => handleInvitation(item)} style={{ cursor: 'pointer' }} color="primary" variant="contained">Answer</Button>
-                              : null}
+                        {item.employeeName ? (
+                          <p>
+                            {item.status === 'accepted' ? (
+                              <div className="status">
+                                <CheckCircleOutlineIcon
+                                  style={{ color: 'green' }}
+                                />
+                                <div>accepted</div>
+                              </div>
+                            ) : (
+                              <div className="status">
+                                <HelpOutlineIcon
+                                  style={{ color: 'purple' }}
+                                />
+                                <div>pending</div>
+                              </div>
+                            )}
                           </p>
-                        }
-                      
+                        ) : (
+                          <p>
+                            {item.status === 'pending' ? (
+                              <Button
+                                onClick={() => handleInvitation(item)}
+                                style={{ cursor: 'pointer' }}
+                                color="primary"
+                                variant="contained"
+                              >
+                                Answer
+                              </Button>
+                            ) : null}
+                          </p>
+                        )}
                       </Grid>
                     </Grid>
                   </Grid>
                 </Paper>
               );
             }
-            })}</div> : 
-          <div className="data-big">
-            <img src={Loader}></img>
-          </div>
-      }
- 
-      {
-        props.invitations ?
-          <div>
-            <div className={classes.root}>
-            </div>
-            {props.invitations.map((item) => { if (item.status == 'accepted') {
+          })}
+        </div>
+      ) : (
+        <div className="data-big">
+          <img src={Loader}></img>
+        </div>
+      )}
+
+      {props.invitations ? (
+        <div>
+          <div className={classes.root}></div>
+          {props.invitations.map(item => {
+            if (item.status == 'accepted') {
               return (
-                <Paper key={item.invitationId} className={classes.paper}>
+                <Paper
+                  key={item.invitationId}
+                  className={classes.paper}
+                >
                   <Grid container spacing={2}>
                     <Grid item xs={12} sm container>
-                      <Grid item xs container direction="column" spacing={2}>
+                      <Grid
+                        item
+                        xs
+                        container
+                        direction="column"
+                        spacing={2}
+                      >
                         <Grid item xs>
-                          <span className="date">{moment(item.invitationDate).format('MMMM Do YYYY').toUpperCase()} AT {item.invitationTime.toUpperCase()}</span>
+                          <span className="date">
+                            {moment(item.invitationDate)
+                              .format('MMMM Do YYYY')
+                              .toUpperCase()}{' '}
+                            AT {item.invitationTime.toUpperCase()}
+                          </span>
 
-                          <Typography className={classes.title} gutterBottom variant="subtitle1">
-                             Meeting with {item.employeeName ? item.employeeName : 'CEO'}
+                          <Typography
+                            className={classes.title}
+                            gutterBottom
+                            variant="subtitle1"
+                          >
+                            Meeting with{' '}
+                            {item.employeeName
+                              ? item.employeeName
+                              : 'CEO'}
                           </Typography>
-                          <p>
-                            {item.comments} 
-                          </p>
+                          <p>{item.comments}</p>
                         </Grid>
                       </Grid>
                       <Grid item>
                         {item.status === 'accepted' ? (
                           <div className="status">
-                            <CheckCircleOutlineIcon style={{ color: 'green' }} />
+                            <CheckCircleOutlineIcon
+                              style={{ color: 'green' }}
+                            />
                             <div>accepted</div>
                           </div>
-                        ) : null }
-                      
+                        ) : null}
                       </Grid>
                     </Grid>
                   </Grid>
                 </Paper>
               );
             }
-            })}</div> : 
-          null
-      }
-
+          })}
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
see #65 for details

Also, sorry, the diff on this is ugly because I fixed a syntax error in the prettier file, and reformatting it caused a bunch of unrelated lines to change. I'm happy to amend the commit to only include my fix, if you'd like.

### Fix

To avoid this, initialize the data in a try/catch so that even the admin views will resolve to an error state if the api request fails, and set an error state ("no permission") for the employee case. In order to `await` the `getAllInvitations` function, and to only run it once on mounting the component, we can wrap it in `useEffect` and then define a function in there, since you can't use an `async` function directly as the callback to `useEffect`.

### Known issues

Most likely, an employee wouldn't see this in the nav bar, correct? In any case, if they had access to the route (assuming this was set up with client side routing eventually), you would still want to handle loading, error, and authorization issues explicitly. Leaving a user stuck in a loading state is usually not the most desirable behavior.